### PR TITLE
Added liblist-moreutils-perl to the list of Debian dependencies.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,8 @@ Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends},
  libqtgui4-perl,
  xterm,
+ liblist-moreutils-perl,
+
 Description: An app that can create chroots, create a live iso from it and rebuild live isos.
  An app that can:
  * create (debootstrap) a debian or ubuntu system;


### PR DESCRIPTION
Without it in Kali 2016.2, `sudo debroot.pl` complains:
Can't locate List/MoreUtils.pm in @INC (you may need to install the List::MoreUtils module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.24.1 /usr/local/share/perl/5.24.1 /usr/lib/x86_64-linux-gnu/perl5/5.24 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.24 /usr/share/perl/5.24 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at /usr/lib/x86_64-linux-gnu/perl5/5.24/QtCore4.pm line 799.
BEGIN failed--compilation aborted at /usr/lib/x86_64-linux-gnu/perl5/5.24/QtCore4.pm line 799.
Compilation failed in require at ./debroot.pl line 6.
BEGIN failed--compilation aborted at ./debroot.pl line 6.